### PR TITLE
Fix cache control header, files are public, /content/images/* results in 404

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ module.exports.save = function(image) {
 // middleware for serving the files
 module.exports.serve = function() {
     // a no-op, these are absolute URLs
-    return function(){};
+    return function (req, res, next) {
+        next();
+    };
 };
 
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports.save = function(image) {
         return nodefn.call(s3.putObject.bind(s3), {
             Bucket: config.bucket,
             Key: targetFilename,
+            ACL: 'public-read',
             Body: buffer,
             ContentType: image.type,
             CacheControl: 'maxage=' + (30 * 24 * 60 * 60) // 30 days

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports.save = function(image) {
             ACL: 'public-read',
             Body: buffer,
             ContentType: image.type,
-            CacheControl: 'maxage=' + (30 * 24 * 60 * 60) // 30 days
+            CacheControl: 'max-age=' + (30 * 24 * 60 * 60) // 30 days
         });
     })
     .then(function(result) {

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports.save = function(image) {
             ACL: 'public-read',
             Body: buffer,
             ContentType: image.type,
-            CacheControl: 'max-age=' + (30 * 24 * 60 * 60) // 30 days
+            CacheControl: 'max-age=' + (365 * 24 * 60 * 60) // 1 year
         });
     })
     .then(function(result) {


### PR DESCRIPTION
The current Cache Control header uses 'maxage' instead of 'max-age' which means that browsers don't honor it. This fixes that, and sets the timeout to be one year from now, which should be fine because every new file uploaded is a unique URL.

Maybe I didn't set my bucket up properly, but I needed to make every file public manually until I added the 'public-read' ACL. I imagine others will run into this.

Lastly, the noop provided by `serve` actually results in a hang whenever a user requests something under the /content/images/ base path. This change makes those requests result in a 404 instead.
