### PR TITLE
Allow dots in s3 bucket name and allow custom CDN path

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ In your ghost config.js file under "development" and "production" add
 Until Ghost has a file module system, you will have to change the file ```storage/index```
 
 ```javascript
-	storage = require('./' + storageChoice);
+	storage[storageChoice] = require('./' + storageChoice);
 ```
 
 becomes
 
 ```javascript
-	storage = require('ghost-s3')({
-	    errors: errors,
-	    config: require('../config')().aws
+	storage[storageChoice] = require('ghost-s3')({
+    errors: errors,
+    config: require('../config').aws
 	});
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ In your ghost config.js file under "development" and "production" add
 	    secretAccessKey: 'your AWS secret access key>',
 	    bucket: 'your-bucket-name',
 	    region: 'the AWS region your bucket is in',
-	    cdnPath: 'path to CDN (e.g. Cloudflare & S3 integration - leave blank if using Amazon CloudFront)'
+	    cdnPath: 'path to CDN (e.g. Cloudflare & S3 integration - leave blank if using Amazon CloudFront)',
+	    prefixPath: 'prefix folder (e.g. images)'
 	},
 
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ In your ghost config.js file under "development" and "production" add
 	    accessKeyId: 'your aws access key id>',
 	    secretAccessKey: 'your AWS secret access key>',
 	    bucket: 'your-bucket-name',
-	    region: 'the AWS region your bucket is in'
+	    region: 'the AWS region your bucket is in',
+	    cdnPath: 'path to CDN (e.g. Cloudflare & S3 integration - leave blank if using Amazon CloudFront)'
 	},
 
 

--- a/index.js
+++ b/index.js
@@ -65,7 +65,9 @@ module.exports.save = function(image) {
 // middleware for serving the files
 module.exports.serve = function() {
     // a no-op, these are absolute URLs
-    return function(){};
+    return function (req, res, next) {
+        next();
+    };
 };
 
 

--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports.save = function(image) {
 
     var targetDir = getTargetDir();
     var targetFilename = getTargetName(image, targetDir);
-    var awsPath = 'https://' + config.bucket + '.s3.amazonaws.com/';
+    var awsPath = 'https://s3.amazonaws.com/' + config.bucket + '/';
     
     // In case using third party CDN (cloudflare-s3 integration, etc)
     var cdnPath = config.cdnPath ? config.cdnPath : awsPath
@@ -75,8 +75,8 @@ module.exports.serve = function() {
 
 
 var MONTHS = [
-    'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
-    'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'
+    '01', '02', '03', '04', '05', '06',
+    '07', '08', '09', '10', '11', '12'
 ];
 var getTargetDir = function() {
     var now = new Date();

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ module.exports.save = function(image) {
         return nodefn.call(s3.putObject.bind(s3), {
             Bucket: config.bucket,
             Key: targetFilename,
+            ACL: 'public-read',
             Body: buffer,
             ContentType: image.type,
             CacheControl: 'maxage=' + (30 * 24 * 60 * 60) // 30 days

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports.save = function(image) {
             ACL: 'public-read',
             Body: buffer,
             ContentType: image.type,
-            CacheControl: 'maxage=' + (30 * 24 * 60 * 60) // 30 days
+            CacheControl: 'max-age=' + (30 * 24 * 60 * 60) // 30 days
         });
     })
     .then(function(result) {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,9 @@ var MONTHS = [
 ];
 var getTargetDir = function() {
     var now = new Date();
-    return path.join(now.getFullYear() + '', MONTHS[now.getMonth()]) + '/';
+    var prefix = config.prefixPath ? config.prefixPath : ''
+    return path.join(prefix, now.getFullYear() + '', 
+        MONTHS[now.getMonth()]) + '/';
 };
 
 

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ module.exports.save = function(image) {
             ACL: 'public-read',
             Body: buffer,
             ContentType: image.type,
-            CacheControl: 'max-age=' + (30 * 24 * 60 * 60) // 30 days
+            CacheControl: 'max-age=' + (365 * 24 * 60 * 60) // 1 year
         });
     })
     .then(function(result) {


### PR DESCRIPTION
CDN path can be used if user is using CloudFlare and uses S3 as virtual host https://support.cloudflare.com/hc/en-us/articles/200168926-How-do-I-use-CloudFlare-with-Amazon-s-S3-Service-

Previously dot is not allowed in s3 bucket name due to ssl constraint, changing the position to `https://s3.amazonaws.com/' + config.bucket + '/';` fixes it
